### PR TITLE
Add Supabase messaging and radar integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,17 @@ npm install
    - Copy `.env.example` to `.env.local`
    - Update the Supabase credentials if needed
 
-4. **Start the development server:**
+4. **Run Supabase migrations:**
+```bash
+cd supabase && npx supabase db reset
+```
+
+5. **Start the development server:**
 ```bash
 npm run dev
 ```
 
-5. **Open your browser:**
+6. **Open your browser:**
    Navigate to `http://localhost:3000`
 
 ## 🏗 Project Structure
@@ -135,6 +140,9 @@ The app is configured to work with Supabase:
 - **Real-time**: Ready for real-time messaging
 - **Storage**: Profile pictures and post media
 - **Database**: User profiles, posts, messages, social accounts
+
+### Messaging Flow
+Messages are stored in the `messages` table. When you start a conversation from the Radar screen the app automatically switches to the Messages tab and loads the chat history from Supabase.
 
 ## 🚀 Deployment
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -240,6 +240,7 @@ export default function App() {
 
   const handleMessageUser = (user: User) => {
     setSelectedChatUser(user);
+    setActiveTab('messages');
   };
 
   const handleViewProfile = (user: User) => {

--- a/src/lib/messages.ts
+++ b/src/lib/messages.ts
@@ -1,0 +1,93 @@
+import { supabase } from './supabase';
+import { Message } from '../types';
+
+export async function sendMessage(
+  senderId: string,
+  receiverId: string,
+  content: string
+): Promise<Message | null> {
+  try {
+    const { data, error } = await supabase
+      .from('messages')
+      .insert({ sender_id: senderId, receiver_id: receiverId, content })
+      .select()
+      .single();
+
+    if (error || !data) {
+      throw error;
+    }
+
+    const message: Message = {
+      id: data.id,
+      senderId: data.sender_id,
+      receiverId: data.receiver_id,
+      content: data.content,
+      timestamp: data.created_at,
+      read: data.read,
+    };
+
+    return message;
+  } catch (err) {
+    console.error('Error sending message:', err);
+    return null;
+  }
+}
+
+export async function getConversation(
+  userId1: string,
+  userId2: string
+): Promise<Message[]> {
+  try {
+    const { data, error } = await supabase
+      .from('messages')
+      .select('*')
+      .or(
+        `and(sender_id.eq.${userId1},receiver_id.eq.${userId2}),and(sender_id.eq.${userId2},receiver_id.eq.${userId1})`
+      )
+      .order('created_at', { ascending: true });
+
+    if (error || !data) {
+      throw error;
+    }
+
+    return data.map((row) => ({
+      id: row.id,
+      senderId: row.sender_id,
+      receiverId: row.receiver_id,
+      content: row.content,
+      timestamp: row.created_at,
+      read: row.read,
+    }));
+  } catch (err) {
+    console.error('Error fetching conversation:', err);
+    return [];
+  }
+}
+
+export async function getConversationsForUser(
+  userId: string
+): Promise<Message[]> {
+  try {
+    const { data, error } = await supabase
+      .from('messages')
+      .select('*')
+      .or(`sender_id.eq.${userId},receiver_id.eq.${userId}`)
+      .order('created_at', { ascending: true });
+
+    if (error || !data) {
+      throw error;
+    }
+
+    return data.map((row) => ({
+      id: row.id,
+      senderId: row.sender_id,
+      receiverId: row.receiver_id,
+      content: row.content,
+      timestamp: row.created_at,
+      read: row.read,
+    }));
+  } catch (err) {
+    console.error('Error fetching conversations:', err);
+    return [];
+  }
+}

--- a/supabase/migrations/20250623170223_create_messages_table.sql
+++ b/supabase/migrations/20250623170223_create_messages_table.sql
@@ -1,0 +1,47 @@
+/*
+  # Create messages table for user chats
+
+  1. New Tables
+    - `messages`
+      - `id` uuid primary key default gen_random_uuid()
+      - `sender_id` uuid references profiles(id)
+      - `receiver_id` uuid references profiles(id)
+      - `content` text
+      - `created_at` timestamptz default now()
+      - `read` boolean default false
+
+  2. Security
+    - Enable RLS on messages
+    - Allow select/insert/update for sender or receiver
+*/
+
+-- Create the messages table
+CREATE TABLE IF NOT EXISTS messages (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  sender_id uuid REFERENCES profiles(id) ON DELETE CASCADE NOT NULL,
+  receiver_id uuid REFERENCES profiles(id) ON DELETE CASCADE NOT NULL,
+  content text NOT NULL,
+  created_at timestamptz DEFAULT now(),
+  read boolean DEFAULT false
+);
+
+-- Enable Row Level Security
+ALTER TABLE messages ENABLE ROW LEVEL SECURITY;
+
+-- Policy: allow participants to view conversation
+CREATE POLICY "Participants can view messages" ON messages
+  FOR SELECT USING (
+    auth.uid() = sender_id OR auth.uid() = receiver_id
+  );
+
+-- Policy: allow participants to insert messages
+CREATE POLICY "Participants can insert messages" ON messages
+  FOR INSERT WITH CHECK (
+    auth.uid() = sender_id OR auth.uid() = receiver_id
+  );
+
+-- Policy: allow sender or receiver to update read status
+CREATE POLICY "Participants can update messages" ON messages
+  FOR UPDATE USING (
+    auth.uid() = sender_id OR auth.uid() = receiver_id
+  );


### PR DESCRIPTION
## Summary
- create `messages` table with RLS policies
- add message utility helpers
- integrate conversations with Supabase in `MessagesScreen`
- mark nearby contacts in `ChatList`
- switch to messages tab automatically
- document messaging setup and migrations

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6859884469f883299afe997bceca8ace