### PR TITLE
Clear location data on logout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,7 @@ export default function App() {
         await handleAuthenticatedUser(session.user);
       } else if (event === 'SIGNED_OUT') {
         console.log('User signed out');
-        handleSignOut();
+        await handleSignOut();
       } else if (event === 'TOKEN_REFRESHED' && session) {
         console.log('Token refreshed successfully');
         // Session is automatically updated by Supabase
@@ -209,7 +209,10 @@ export default function App() {
     setCurrentScreen('app');
   };
 
-  const handleSignOut = () => {
+  const handleSignOut = async () => {
+    // Ensure location is cleared from the database
+    await locationToggleManager.turnOff();
+
     setIsLoggedIn(false);
     setCurrentUser(null);
     setCurrentScreen('welcome');
@@ -217,7 +220,7 @@ export default function App() {
     setSelectedUser(null);
     setSelectedChatUser(null);
     setIsNavigationVisible(true);
-    
+
     // Clear location toggle state on logout
     locationToggleManager.clearPersistedState();
   };
@@ -234,7 +237,7 @@ export default function App() {
     } catch (error) {
       console.error('Logout error:', error);
       // Force sign out anyway
-      handleSignOut();
+      await handleSignOut();
     }
   };
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,5 @@
 import { supabase, ensureSession } from './supabase'
+import { locationToggleManager } from './locationToggle'
 
 export interface AuthResponse {
   success: boolean
@@ -508,6 +509,8 @@ export const signOut = async (): Promise<AuthResponse> => {
   }
 
   try {
+    await locationToggleManager.turnOff()
+    locationToggleManager.clearPersistedState()
     const { error } = await supabase!.auth.signOut()
     
     if (error) {
@@ -572,6 +575,8 @@ export const getCurrentUser = async (): Promise<AuthResponse> => {
 export const handleRefreshTokenError = async (): Promise<void> => {
   try {
     console.log('Handling refresh token error - signing out user')
+    await locationToggleManager.turnOff()
+    locationToggleManager.clearPersistedState()
     await supabase!.auth.signOut()
     
     // Clear any cached data


### PR DESCRIPTION
## Summary
- clear stored location when logging out
- remove location when auth token refresh fails

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ad7dd662883298abd6499f19a1fa4