### PR TITLE
Fix avatar src error

### DIFF
--- a/src/components/common/Avatar.tsx
+++ b/src/components/common/Avatar.tsx
@@ -22,7 +22,7 @@ export const Avatar: React.FC<Props> = ({
   return (
     <div className="relative inline-block">
       <img
-        src={src}
+        src={src || undefined}
         alt={alt}
         className={`
           ${sizeClasses[size]}


### PR DESCRIPTION
## Summary
- avoid passing an empty string to the Avatar `img` tag

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68622c36cf888329bedc1734e648c751